### PR TITLE
add minor fixes to readme + caddy tutorial

### DIFF
--- a/doc/setup-ssg-caddy-debian.md
+++ b/doc/setup-ssg-caddy-debian.md
@@ -41,13 +41,7 @@ nubio ssg profile.json .out # Generate website files
 ## Update your DNS
 
 - Ensure your domain resolves to your server's IP address(es).
-- Ensure you have a CNAME on `www.` pointing to `www.alexdoe.example.`.
-
-## Copy static files to remote server
-
-```bash
-scp -r .out/* root@alexdoe.example:/var/www/alexdoe
-```
+- Ensure you have a CNAME on `www.` pointing to `alexdoe.example.`.
 
 ## Setup Caddy on the remote server
 
@@ -93,6 +87,14 @@ www.alexdoe.example {
 Restart Caddy:
 ```bash
 systemctl restart caddy && systemctl status caddy
+```
+
+## Copy static files to remote server
+
+From your local machine, copy the static files created by `nubio` to the remote server:
+
+```bash
+scp -r .out/* root@alexdoe.example:/var/www/alexdoe
 ```
 
 Your website is now up and running!
@@ -141,7 +143,7 @@ jobs:
           go-version: "1.21.7"
       - name: Build and deploy.
         run: |
-          go install github.com/ejuju/nubio@v0.2.7
+          go install github.com/ejuju/nubio@v0.3.1
           mkdir .out
           nubio check-profile profile.json
           nubio ssg profile.json .out
@@ -162,5 +164,5 @@ git push
 ```
 
 CI/CD is setup!
-You can now make modifications to your profile.json and
+You can now make modifications to your `profile.json` and
 the new changes will be deployed when you push.

--- a/readme.md
+++ b/readme.md
@@ -53,9 +53,11 @@ Your `profile.json` can include:
 - Hobbies
 
 Here's a JSON template you can fill in with your information:
+
 ```json
 {
     "name": "",
+    "domain": "",
     "contact": {"email_address": ""},
     "links": [
         {"label": "", "url": ""},
@@ -91,6 +93,12 @@ Here's a JSON template you can fill in with your information:
 ```
 
 Note: See `example.profile.json` for a realistic example.
+
+You can check the validity of your `profile.json` with:
+
+```bash
+nubio check-profile profile.json
+```
 
 ### Generating a static website (SSG)
 


### PR DESCRIPTION
Readme:
- add "domain" field in `profile.json` example
- add `check-profile` command mention

Caddy tutorial:
- move `scp` static files to after installing Caddy (cannot `scp` to `/var/www/alexdoe` before `mkdir -p /var/www/alexdoe`)
- fix CNAME line typo
- fix version on CICD example: v0.2.7 does not support required `check-profile` command
