### PR TITLE
fix typo work experience

### DIFF
--- a/pkg/nubio/pdf.go
+++ b/pkg/nubio/pdf.go
@@ -68,7 +68,7 @@ func ExportPDF(w io.Writer, p *Profile) error {
 
 	// Append work experiences.
 	pdf.Ln(24)
-	writeHeading(pdf, "Experiences")
+	writeHeading(pdf, "Work Experience")
 	for _, v := range p.Experiences {
 		pdf.Ln(16)
 		pdf.SetFontSize(fontSize)

--- a/pkg/nubio/profile.html.gotmpl
+++ b/pkg/nubio/profile.html.gotmpl
@@ -182,7 +182,7 @@
         </section>
 
         <section id="experiences" class="card">
-            <h2>Work experiences</h2>
+            <h2>Work Experience</h2>
             {{- range .Experiences }}
             <hr>
             <section class="grid-12px">

--- a/pkg/nubio/profile.md.gotmpl
+++ b/pkg/nubio/profile.md.gotmpl
@@ -1,6 +1,6 @@
 # {{ .Name }}
 
-## Work experiences
+## Work Experience
 {{ range .Experiences }}
 |              |   |
 |--------------|---|

--- a/pkg/nubio/profile.txt.gotmpl
+++ b/pkg/nubio/profile.txt.gotmpl
@@ -1,6 +1,6 @@
 Hi, I'm {{ .Name }}!
 
-Work experiences:
+Work Experience:
 {{ range .Experiences }}
 - Title: {{ .Title }}
 - Organization: {{ .Organization }}

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ usually named `profile.json`.
 Your `profile.json` can include:
 - Contact details
 - External links
-- Work experiences
+- Work Experience
 - Skills
 - Languages
 - Education


### PR DESCRIPTION
"Work Experience" (singular) works better on a CV because it presents an overall summary of all your past roles. "Work experiences" refers to individual events or specific moments (like handling an emergency one day) rather than the general picture of your career.